### PR TITLE
Fix: Swoll hides meat in bag

### DIFF
--- a/src/window.cpp
+++ b/src/window.cpp
@@ -45,16 +45,16 @@ void Window::PrintInformation(Player player){
 }
 void Window::PrintBag(Player player){
   erase();
-  int i=0;
+  int i,l=0;
   if(player.HasSwoll()){
-    mvprintw(i,0,"Swoll - the weapon increase your attack");
-    i++;
+    mvprintw(l,0,"Swoll - the weapon increase your attack");
+    l++;
   }
   std::vector<char> item = player.GetItem();
-  for(;i<player.GetItemCount();i++){
+  for(i=0;i<player.GetItemCount();i++,l++){
     if(strchr("m",item[i]))
-    mvprintw(i,0,"Meat - a thing to eat to recover HP");
-    else mvprintw(i,0,"Unknown - Something unexpected");
+    mvprintw(l,0,"Meat - a thing to eat to recover HP");
+    else mvprintw(l,0,"Unknown - Something unexpected");
   }
   refresh();
 }


### PR DESCRIPTION
Having the Swoll in your bag causes the first meat in your inventory to
be skipped and not printed, because the variable tracking which line to
print on and the variable used to iterate through the hero's inventory
were the same.  Split them into two variables so iterating through the
bag will start at items[0] even if the Swoll line has been printed.